### PR TITLE
На Windows потребовалось указать кодировку

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     author_email='suor.web@gmail.com',
 
     description='Parse SWGoH tickets screenshots.',
-    long_description=open('README.md').read(),
+    long_description=open('README.md',  encoding='utf8').read(),
     url='http://github.com/Suor/swgoh-tickets-ocr',
     license='BSD',
 


### PR DESCRIPTION
Установка не работала на Windows, так как по умолчанию питон пытался прочитать README.md в кодировке CP-1251. Явное указание кодировки решило проблему